### PR TITLE
Fix memory leaks

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -3,8 +3,8 @@
 #include <evhttp.h>
 
 #define PARSE_URI(request, params) { \
-    char const *uri = evhttp_request_uri(request); \
-    evhttp_parse_query(uri, &params); \
+    const char *query_part = evhttp_uri_get_query(request->uri_elems); \
+    evhttp_parse_query_str(query_part, &params); \
 }
 
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -116,6 +116,8 @@ static void http_pinyin_callback(struct evhttp_request *request, void *data) {
 
     evhttp_send_reply(request, HTTP_OK, "", buffer);
 
+    evhttp_clear_headers(&params_get);
+    evbuffer_free(buffer);
 }
 
 /**** uri: /jyutping?str=*
@@ -148,6 +150,8 @@ static void http_jyutping_callback(struct evhttp_request *request, void *data) {
 
     evhttp_send_reply(request, HTTP_OK, "", buffer);
 
+    evhttp_clear_headers(&params_get);
+    evbuffer_free(buffer);
 }
 
 
@@ -182,6 +186,8 @@ static void http_change_script_callback(struct evhttp_request *request, void *da
 
     evhttp_send_reply(request, HTTP_OK, "", buffer);
 
+    evhttp_clear_headers(&params_get);
+    evbuffer_free(buffer);
 }
 
 
@@ -218,6 +224,8 @@ static void http_trad_callback(struct evhttp_request *request, void *data) {
 
     evhttp_send_reply(request, HTTP_OK, "", buffer);
 
+    evhttp_clear_headers(&params_get);
+    evbuffer_free(buffer);
 }
 
 
@@ -253,6 +261,8 @@ static void http_simp_callback(struct evhttp_request *request, void *data) {
 
     evhttp_send_reply(request, HTTP_OK, "", buffer);
 
+    evhttp_clear_headers(&params_get);
+    evbuffer_free(buffer);
 }
 
 
@@ -294,6 +304,8 @@ static void http_guess_script_callback(struct evhttp_request *request, void *dat
 
     evhttp_send_reply(request, HTTP_OK, "", buffer);
 
+    evhttp_clear_headers(&params_get);
+    evbuffer_free(buffer);
 }
 
 
@@ -337,6 +349,8 @@ static void http_all_callback(struct evhttp_request *request, void *data) {
 
     evhttp_send_reply(request, HTTP_OK, "", buffer);
 
+    evhttp_clear_headers(&params_get);
+    evbuffer_free(buffer);
 }
 
 


### PR DESCRIPTION
I tracked down the memory leak that made sinoparserd use more and more memory over time. Memory usage now seems stable over time. I also removed a deprecated function while I was at it. Note that I spot some other memory leaks that occurred during the initial XML parsing, but since this is only performed during startup, we can live with it for the time being.

Please backport it to nihongoparserd if you have time.